### PR TITLE
Fix Wordcount unit test for Xcode 6 beta 4

### DIFF
--- a/word-count/WordCountTest.swift
+++ b/word-count/WordCountTest.swift
@@ -2,11 +2,16 @@ import XCTest
 
 class WordCountTest: XCTestCase {
     
+    func XCTAssertEqualDictionaries <S, T> (first: [S:T], _ second: [S:T]) {
+                XCTAssertEqual(first.bridgeToObjectiveC(), second.bridgeToObjectiveC())
+            }
+    
     func testCountOneWord() {
         let words = WordCount(words: "word")
         let expected = ["word": 1]
         let result = words.count()
-        XCTAssertEqualObjects(expected, result)
+        
+        XCTAssertEqualDictionaries(expected, result)
     }
     
     func testCountOneOfEeach() {
@@ -14,38 +19,39 @@ class WordCountTest: XCTestCase {
         let expected = ["one" : 1, "of" : 1, "each" : 1 ]
         let result = words.count();
         
-        XCTAssertEqualObjects(expected, result)
+        XCTAssertEqualDictionaries(expected, result)
     }
     
     func testCountMultipleOccurrences() {
         let words = WordCount(words: "one fish two fish red fish blue fish")
         let expected = ["one" : 1, "fish" : 4, "two" : 1, "red" : 1, "blue" : 1 ]
         let result = words.count()
-        XCTAssertEqualObjects(expected, result)
+        
+        XCTAssertEqualDictionaries(expected, result)
     }
-
+    
     func testIgnorePunctation() {
         let words = WordCount(words: "car : carpet as java : javascript!!&$%^&")
         let expected = ["car" : 1, "carpet" : 1, "as" : 1, "java" : 1, "javascript" : 1 ]
         let result = words.count()
         
-        XCTAssertEqualObjects(expected, result)
+        XCTAssertEqualDictionaries(expected, result)
     }
     
     func testIncludeNumbers() {
         let words = WordCount(words: "testing, 1, 2 testing")
         let expected = [ "testing" : 2, "1" : 1, "2" : 1 ]
         let result = words.count()
+        
+        XCTAssertEqualDictionaries(expected, result)
+    }
     
-        XCTAssertEqualObjects(expected, result)
-        }
-
     func testNormalizeCase() {
         let words = WordCount(words:"go Go GO")
         let expected = [ "go" : 3]
         let result = words.count()
-    
-        XCTAssertEqualObjects(expected, result)
+        
+        XCTAssertEqualDictionaries(expected, result)
     }
-
+    
 }


### PR DESCRIPTION
Fix for issue https://github.com/exercism/xswift/issues/4

I imagine that's a correct approach until Swift Dictionary become Equatable or XTCAssertEqualObjects makes a come back
