### PR TITLE
Use XCTAssertEqual to compare Dictionary results.

### DIFF
--- a/etl/EtlTest.swift
+++ b/etl/EtlTest.swift
@@ -2,16 +2,12 @@ import XCTest
 
 class EtlTest: XCTestCase {
 
-    func XCTAssertEqualDictionaries <S, T> (first: [S:T], _ second: [S:T]) {
-        XCTAssertEqual(first.bridgeToObjectiveC(), second.bridgeToObjectiveC())
-    }
-
     func testTransformOneValue() {
         let old = [ 1 : [ "A" ] ]
         let expected =  ["a" : 1 ]
         let results = ETL.transform(old)
         
-        XCTAssertEqualDictionaries(results, expected)
+        XCTAssertEqual(results, expected)
     }
     
     func testTransformMoreValues() {
@@ -19,7 +15,7 @@ class EtlTest: XCTestCase {
         let expected =  ["a" : 1, "e": 1, "i": 1, "o": 1, "u": 1 ]
         let results = ETL.transform(old)
         
-        XCTAssertEqualDictionaries(results, expected)
+        XCTAssertEqual(results, expected)
     }
     
     func testMoreKeys() {
@@ -27,7 +23,7 @@ class EtlTest: XCTestCase {
         let expected =  ["a" : 1, "e": 1, "d": 2, "g": 2 ]
         let results = ETL.transform(old)
         
-        XCTAssertEqualDictionaries(results, expected)
+        XCTAssertEqual(results, expected)
     }
     
     func testFullDataSet() {
@@ -48,7 +44,7 @@ class EtlTest: XCTestCase {
         
         let results = ETL.transform(old)
         
-        XCTAssertEqualDictionaries(results, expected)
+        XCTAssertEqual(results, expected)
         
     }
     

--- a/word-count/WordCountTest.swift
+++ b/word-count/WordCountTest.swift
@@ -2,16 +2,12 @@ import XCTest
 
 class WordCountTest: XCTestCase {
     
-    func XCTAssertEqualDictionaries <S, T> (first: [S:T], _ second: [S:T]) {
-                XCTAssertEqual(first.bridgeToObjectiveC(), second.bridgeToObjectiveC())
-            }
-    
     func testCountOneWord() {
         let words = WordCount(words: "word")
         let expected = ["word": 1]
         let result = words.count()
         
-        XCTAssertEqualDictionaries(expected, result)
+        XCTAssertEqual(expected, result)
     }
     
     func testCountOneOfEeach() {
@@ -19,7 +15,7 @@ class WordCountTest: XCTestCase {
         let expected = ["one" : 1, "of" : 1, "each" : 1 ]
         let result = words.count();
         
-        XCTAssertEqualDictionaries(expected, result)
+        XCTAssertEqual(expected, result)
     }
     
     func testCountMultipleOccurrences() {
@@ -27,7 +23,7 @@ class WordCountTest: XCTestCase {
         let expected = ["one" : 1, "fish" : 4, "two" : 1, "red" : 1, "blue" : 1 ]
         let result = words.count()
         
-        XCTAssertEqualDictionaries(expected, result)
+        XCTAssertEqual(expected, result)
     }
     
     func testIgnorePunctation() {
@@ -35,7 +31,7 @@ class WordCountTest: XCTestCase {
         let expected = ["car" : 1, "carpet" : 1, "as" : 1, "java" : 1, "javascript" : 1 ]
         let result = words.count()
         
-        XCTAssertEqualDictionaries(expected, result)
+        XCTAssertEqual(expected, result)
     }
     
     func testIncludeNumbers() {
@@ -43,7 +39,7 @@ class WordCountTest: XCTestCase {
         let expected = [ "testing" : 2, "1" : 1, "2" : 1 ]
         let result = words.count()
         
-        XCTAssertEqualDictionaries(expected, result)
+        XCTAssertEqual(expected, result)
     }
     
     func testNormalizeCase() {
@@ -51,7 +47,7 @@ class WordCountTest: XCTestCase {
         let expected = [ "go" : 3]
         let result = words.count()
         
-        XCTAssertEqualDictionaries(expected, result)
+        XCTAssertEqual(expected, result)
     }
     
 }


### PR DESCRIPTION
The older generics-based XCTAssertEqualDictionaries doesn't compile
under modern Xcode because the bridgeToObjectiveC() function was removed.

XCTAssertEqual seems to work as well as the other function now, so we should use it.
