### PR TITLE
WordCountTest.swift

### DIFF
--- a/word-count/WordCountTest.swift
+++ b/word-count/WordCountTest.swift
@@ -2,12 +2,16 @@ import XCTest
 
 class WordCountTest: XCTestCase {
     
+    func XCTAssertEqualDictionaries<S, T: Equatable> (first: [S:T], _ second: [S:T]) {
+        XCTAssert(first == second)
+    }
+    
     func testCountOneWord() {
         let words = WordCount(words: "word")
         let expected = ["word": 1]
         let result = words.count()
         
-        XCTAssertEqual(expected, result)
+        XCTAssertEqualDictionaries(expected, result)
     }
     
     func testCountOneOfEeach() {
@@ -15,7 +19,7 @@ class WordCountTest: XCTestCase {
         let expected = ["one" : 1, "of" : 1, "each" : 1 ]
         let result = words.count();
         
-        XCTAssertEqual(expected, result)
+        XCTAssertEqualDictionaries(expected, result)
     }
     
     func testCountMultipleOccurrences() {
@@ -23,7 +27,7 @@ class WordCountTest: XCTestCase {
         let expected = ["one" : 1, "fish" : 4, "two" : 1, "red" : 1, "blue" : 1 ]
         let result = words.count()
         
-        XCTAssertEqual(expected, result)
+        XCTAssertEqualDictionaries(expected, result)
     }
     
     func testIgnorePunctation() {
@@ -31,7 +35,7 @@ class WordCountTest: XCTestCase {
         let expected = ["car" : 1, "carpet" : 1, "as" : 1, "java" : 1, "javascript" : 1 ]
         let result = words.count()
         
-        XCTAssertEqual(expected, result)
+        XCTAssertEqualDictionaries(expected, result)
     }
     
     func testIncludeNumbers() {
@@ -39,7 +43,7 @@ class WordCountTest: XCTestCase {
         let expected = [ "testing" : 2, "1" : 1, "2" : 1 ]
         let result = words.count()
         
-        XCTAssertEqual(expected, result)
+        XCTAssertEqualDictionaries(expected, result)
     }
     
     func testNormalizeCase() {
@@ -47,7 +51,7 @@ class WordCountTest: XCTestCase {
         let expected = [ "go" : 3]
         let result = words.count()
         
-        XCTAssertEqual(expected, result)
+        XCTAssertEqualDictionaries(expected, result)
     }
     
 }


### PR DESCRIPTION
Reintroduced AssertEqualDictionaries in order to prevent Type '[String : Int]' does not conform to protocol 'Equatable' when passing in a dict to the tests.
