### PR TITLE
Invalid response to forceful question in test case

### DIFF
--- a/bob/BobTest.swift
+++ b/bob/BobTest.swift
@@ -39,7 +39,7 @@ class BobTests: XCTestCase {
     
     func testForcefulQuestions() {
         let input = "WHAT THE HELL WERE YOU THINKING?"
-        let expected = "Woah, chill out!"
+        let expected = "Sure."
         let result = Bob.hey(input)
         XCTAssertEqual(expected, result)
     }


### PR DESCRIPTION
Imo the response to a forceful question should be "Sure.". The spec isn't perfectly clear but the question requirement comes before the shouting requirement and should have precedence.