### PR TITLE
Use enum and struct to model nucleotide and DNA

### DIFF
--- a/nucleotide-count/NucleotideCountExample.swift
+++ b/nucleotide-count/NucleotideCountExample.swift
@@ -26,4 +26,13 @@ struct DNA {
         return nucleotideCounts[Nucleobase(rawValue: value)!]!
     }
     
+    func counts()->[String: Int] {
+        var nCounts:[String:Int] = [:]
+        for (k, v) in nucleotideCounts {
+            nCounts[String(k.rawValue)] = v
+        }
+        return nCounts
+    }
+    
 }
+

--- a/nucleotide-count/NucleotideCountExample.swift
+++ b/nucleotide-count/NucleotideCountExample.swift
@@ -1,43 +1,29 @@
 import Foundation
 
-class DNA {
-    
-    class func withStrand(strand: String) -> DNA? {
-        if (strand.rangeOfCharacterFromSet(invalidDNANucleotides(), options: NSStringCompareOptions.LiteralSearch) != nil) {
-            return nil
-        }
-        var result = DNA()
-        result.DNAStrand = strand
-        return result
-    }
-    
-    var DNAStrand = ""
-    var nucleotideCounts: Dictionary<String, Int> {
-        get {
-            var result = ["A": 0 , "T": 0, "C": 0, "G": 0]
-            for (k, _) in result {
-                result[k] = self.count(k)
-            }
-            return result
-        }
-    }
-    
-    func count(target: String) -> Int? {
-        
-        if (target.rangeOfCharacterFromSet(invalidDNANucleotides(), options: NSStringCompareOptions.LiteralSearch) != nil) {
-            return nil
-        }
-        var matches = 0
-        for char in DNAStrand {
-            if "\(char)" == target {
-                matches++
-            }
-        }
-        return matches
-    }
-
+enum Nucleobase: Character {
+    case Adenine = "A",
+    Cytosine = "C",
+    Thymine = "T",
+    Guanine = "G"
 }
 
-func invalidDNANucleotides() -> NSCharacterSet {
-    return NSCharacterSet(charactersInString: "ACGT").invertedSet
+struct DNA {
+    
+    var nucleotideCounts:[Nucleobase:Int] = [ .Adenine: 0, .Thymine: 0, .Cytosine: 0 , .Guanine : 0 ]
+    
+    init?(strand: String) {
+        for (_, value) in strand.characters.enumerate() {
+            if let possibleNucleobase = Nucleobase(rawValue: value) {
+                nucleotideCounts[possibleNucleobase]! += 1
+            }
+            else {
+                return nil
+            }
+        }
+    }
+    
+    func count(value :Character)-> Int {
+        return nucleotideCounts[Nucleobase(rawValue: value)!]!
+    }
+    
 }

--- a/nucleotide-count/NucleotideCountTest.swift
+++ b/nucleotide-count/NucleotideCountTest.swift
@@ -9,11 +9,10 @@ class NucleotideCountTests: XCTestCase
         XCTAssertEqual(result, expected)
     }
     
-    // An initializer defined with init can be made failable by adding a ? or a ! after the init
     func testEmptyDNAStringHasNoNucleotides() {
         let dna = DNA(strand: "")!
-        let results = dna.nucleotideCounts
-        let expected:[Nucleobase:Int] = [ .Adenine: 0, .Thymine: 0, .Cytosine: 0 , .Guanine : 0 ]
+        let results = dna.counts()
+        let expected = ["T": 0, "A": 0, "C": 0, "G": 0]
         XCTAssertEqual(results, expected)
     }
     
@@ -26,8 +25,8 @@ class NucleotideCountTests: XCTestCase
     
     func testRepetitiveSequenceHasOnlyGuanosine() {
         let dna = DNA(strand: "GGGGGGGG")!
-        let results = dna.nucleotideCounts
-        let expected:[Nucleobase:Int] = [ .Adenine: 0, .Thymine: 0, .Cytosine: 0 , .Guanine : 8 ]
+        let results = dna.counts()
+        let expected = [ "A": 0, "T": 0, "C": 0 , "G": 8 ]
         XCTAssertEqual(results, expected)
     }
     
@@ -40,8 +39,7 @@ class NucleotideCountTests: XCTestCase
     
     func testCountsANucleotideOnlyOnce() {
         let dna = DNA(strand: "CGATTGGG")!
-        var result = dna.count("T")
-        result = dna.count("T")
+        let result = dna.count("T")
         let expected = 2
         XCTAssertEqual(result, expected)
     }
@@ -53,8 +51,8 @@ class NucleotideCountTests: XCTestCase
     func testCountsAllNucleotides() {
         let longStrand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
         let dna = DNA(strand: longStrand)!
-        let results = dna.nucleotideCounts
-        let expected:[Nucleobase:Int] = [ .Adenine: 20, .Thymine: 21, .Cytosine: 12 , .Guanine : 17 ]
+        let results = dna.counts()
+        let expected = [ "A": 20, "T": 21,"C": 12 , "G" : 17 ]
         XCTAssertEqual(results, expected)
     }
 }

--- a/nucleotide-count/NucleotideCountTest.swift
+++ b/nucleotide-count/NucleotideCountTest.swift
@@ -1,60 +1,60 @@
 import XCTest
 
-class NucleotideCountTest: XCTestCase
+class NucleotideCountTests: XCTestCase
 {
     func testEmptyDNAStringHasNoAdenosine() {
-        let dna = DNA.withStrand("")!
+        let dna = DNA(strand: "")!
         let result = dna.count("A")
         let expected = 0
-        XCTAssertEqual(result!, expected)
+        XCTAssertEqual(result, expected)
     }
     
+    // An initializer defined with init can be made failable by adding a ? or a ! after the init
     func testEmptyDNAStringHasNoNucleotides() {
-        let dna = DNA.withStrand("")!
+        let dna = DNA(strand: "")!
         let results = dna.nucleotideCounts
-        let expected = [ "A": 0, "T" : 0, "C" : 0, "G" : 0 ]
+        let expected:[Nucleobase:Int] = [ .Adenine: 0, .Thymine: 0, .Cytosine: 0 , .Guanine : 0 ]
         XCTAssertEqual(results, expected)
     }
     
     func testRepetitiveCytidineGetsCounted() {
-        let dna = DNA.withStrand("CCCCC")!
-        let result = dna.count("C")!
+        let dna = DNA(strand: "CCCCC")!
+        let result = dna.count("C")
         let expected = 5
         XCTAssertEqual(result, expected)
     }
     
     func testRepetitiveSequenceHasOnlyGuanosine() {
-        let dna = DNA.withStrand("GGGGGGGG")!
+        let dna = DNA(strand: "GGGGGGGG")!
         let results = dna.nucleotideCounts
-        let expected = [ "A": 0, "T" : 0, "C" : 0, "G" : 8 ]
+        let expected:[Nucleobase:Int] = [ .Adenine: 0, .Thymine: 0, .Cytosine: 0 , .Guanine : 8 ]
         XCTAssertEqual(results, expected)
     }
     
     func testCountsByThymidine() {
-        let dna = DNA.withStrand("GGGGGTAACCCGG")!
-        let result = dna.count("T")!
+        let dna = DNA(strand: "GGGGGTAACCCGG")!
+        let result = dna.count("T")
         let expected = 1
         XCTAssertEqual(result, expected)
     }
     
     func testCountsANucleotideOnlyOnce() {
-        let dna = DNA.withStrand("CGATTGGG")!
-        var result = dna.count("T")!
-        result = dna.count("T")!
+        let dna = DNA(strand: "CGATTGGG")!
+        var result = dna.count("T")
+        result = dna.count("T")
         let expected = 2
         XCTAssertEqual(result, expected)
     }
     
     func testValidatesDNA() {
-        let dna = DNA.withStrand("John")
-        XCTAssert(dna == nil)
+        XCTAssert(DNA(strand: "John") == nil )
     }
     
     func testCountsAllNucleotides() {
-        var longStrand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
-        let dna = DNA.withStrand(longStrand)!
+        let longStrand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
+        let dna = DNA(strand: longStrand)!
         let results = dna.nucleotideCounts
-        let expected = [ "A": 20, "T" : 21, "C" : 12, "G" : 17 ]
+        let expected:[Nucleobase:Int] = [ .Adenine: 20, .Thymine: 21, .Cytosine: 12 , .Guanine : 17 ]
         XCTAssertEqual(results, expected)
     }
 }


### PR DESCRIPTION
I tried to add some swift approaches to this example. 

1. The DNA should be modeled as a struct since the following apply to it.
*The structure’s primary purpose is to encapsulate a few relatively simple data values.
It is reasonable to expect that the encapsulated values will be copied rather than referenced when you assign or pass around an instance of that structure.
Any properties stored by the structure are themselves value types, which would also be expected to be copied rather than referenced.
The structure does not need to inherit properties or behavior from another existing type.*
 
2. The nucleobases(A,C,T,G) are enums, which is sort of self-explanatory. Nice that swift allows enums to be `Character` type.

3. The Optional Bindings `if let` made sense when converting from RawValue of `Character` to `enum`.

4. The DNA `struct` has a failable initializer created by adding `?` to `init` and returns `nil` if the strand has an invalid character.


