### PR TITLE
Update GradeSchool{Example,Test}

### DIFF
--- a/grade-school/GradeSchoolExample.swift
+++ b/grade-school/GradeSchoolExample.swift
@@ -2,32 +2,27 @@
 
 // Apple Swift version 2.0
 
-class GradeSchool {
-    var db: [Int: [String]] = [:]
-        
-    func addStudent(name: String, grade: Int) {
-        if var students = db[grade] {
+struct GradeSchool {
+    var roster = [Int: [String]]()
+
+    mutating func addStudent(name: String, grade: Int) {
+        if var students = roster[grade] {
             students.append(name)
-            db[grade] = students
+            roster[grade] = students
         } else {
-            db[grade] = [name]
+            roster[grade] = [name]
         }
     }
-    
-    func studentsInGrade(grade: Int) -> [String]
-    {
-        if let students = db[grade] {
-            return students
-        } else {
-            return []
-        }
+
+    func studentsInGrade(grade: Int) -> [String] {
+        return roster[grade] ?? []
     }
-    
-    func sortedRoster() -> [Int: [String]] {
-        var sortedDB = db
-        for (grade, students) in sortedDB {
-            sortedDB[grade] = students.sort(<)
+
+    var sortedRoster: [Int: [String]] {
+        var sortedRoster = [Int: [String]](minimumCapacity: roster.count)
+        for (grade, students) in roster {
+            sortedRoster[grade] = students.sort(<)
         }
-        return sortedDB
+        return sortedRoster
     }
 }

--- a/grade-school/GradeSchoolTest.swift
+++ b/grade-school/GradeSchoolTest.swift
@@ -2,82 +2,89 @@ import XCTest
 
 // Apple Swift version 2.0
 
-class GradeSchoolTest: XCTestCase
-{
-
+class GradeSchoolTest: XCTestCase {
     func testAnEmptySchool() {
-        let school = GradeSchool()
+        let school   = GradeSchool()
         let expected = [:]
-        let result = school.db
+        let result   = school.roster
         XCTAssertEqual(result, expected)
     }
-    
+
     func testAddStudent() {
-        let school = GradeSchool()
+        var school = GradeSchool()
         school.addStudent("Aimee", grade: 2)
-        let result = school.db
+        let result = school.roster
         let expected: Dictionary = [2: ["Aimee"]]
         XCTAssertEqual(Array(result.keys), Array(expected.keys))
-        XCTAssertEqual(result[2]!, expected[2]!)
+        XCTAssert(sameStudents(result[2], expected[2]))
     }
 
     func testAddMoreStudentsInSameClass() {
-        let school = GradeSchool()
+        var school = GradeSchool()
         school.addStudent("Fred", grade: 2)
         school.addStudent("James", grade: 2)
         school.addStudent("Paul", grade: 2)
-        let result = school.db
+        let result   = school.roster
         let expected = [2: ["Fred", "James", "Paul"]]
         XCTAssertEqual(Array(result.keys), Array(expected.keys))
-        XCTAssertEqual(result[2]!, expected[2]!)
+        XCTAssert(sameStudents(result[2], expected[2]))
     }
 
     func testAddStudentsToDifferentGrades() {
-        let school = GradeSchool()
-        school.addStudent("Chelsea", grade: 3)
+        var school = GradeSchool()
+        school.addStudent("Chelsea", grade:3)
         school.addStudent("Logan", grade: 7)
-        let result = school.db
+        let result = school.roster
         let expected = [3: ["Chelsea"], 7: ["Logan"]]
         XCTAssertEqual(Array(result.keys).sort(>), Array(expected.keys).sort(>))
-        XCTAssertEqual(result[3]!, expected[3]!)
+        XCTAssert(sameStudents(result[3], expected[3]))
     }
 
     func testGetStudentsInAGrade() {
-        let school = GradeSchool()
+        var school = GradeSchool()
         school.addStudent("Franklin", grade: 5)
         school.addStudent("Bradley", grade: 5)
         school.addStudent("Jeff", grade: 1)
-        let result = school.studentsInGrade(5)
-        let expected = [ "Franklin", "Bradley" ]
-        XCTAssertEqual(result, expected)
+        let result   = school.studentsInGrade(5)
+        let expected = ["Franklin", "Bradley"]
+        XCTAssert(sameStudents(result, expected))
     }
 
     func testGetStudentsInANonExistantGrade() {
         let school = GradeSchool()
         let result = school.studentsInGrade(1)
-    
-        let expected: [String] = []
-        XCTAssertEqual(result, expected)
+
+        let expected = [String]()
+        XCTAssert(sameStudents(result, expected))
     }
 
     func testSortSchool() {
-        let school = GradeSchool()
-        
-        school.addStudent("Jennifer", grade:4)
-        school.addStudent("Kareem", grade:6)
-        school.addStudent("Christopher", grade:4)
+        var school = GradeSchool()
+        school.addStudent("Jennifer", grade: 4)
+        school.addStudent("Kareem", grade: 6)
+        school.addStudent("Christopher", grade: 4)
         school.addStudent("Kyle", grade: 3)
-        let result = school.sortedRoster()
-        
+        let result = school.sortedRoster
+
         let expected = [
             3 : ["Kyle"],
-            4 : [ "Christopher", "Jennifer" ],
-            6 : [ "Kareem"]
+            4 : ["Christopher", "Jennifer"],
+            6 : ["Kareem"]
         ]
-        
+
         XCTAssertEqual(Array(result.keys).sort(>), Array(expected.keys).sort(>))
-        XCTAssertEqual(result[3]!, expected[3]!)
-        XCTAssertEqual(result[4]!, expected[4]!)
-        XCTAssertEqual(result[6]!, expected[6]!)
+        XCTAssert(sameStudents(result[3], expected[3]))
+        XCTAssert(sameStudents(result[4], expected[4]))
+        XCTAssert(sameStudents(result[6], expected[6]))
+    }
+
+    func sameStudents<C: CollectionType where C.Generator.Element == String>(result: C?, _ expected: [String]?) -> Bool {
+        guard let result = result, expected = expected else { return false }
+
+        for (index, student) in result.enumerate() {
+            guard index < expected.count && expected.contains(student) else { return false }
+        }
+
+        return true
     }
 }


### PR DESCRIPTION
Test:

- Fix minor formatting issues
- Add generic `sameStudents(_:_:)` to allow more flexibility in solutions
- Avoid unnecessarily forced coercion
- `s/db/roster/g; s/sortedRoster\(\)/sortedRoster/g;`

Example:

- Use a `struct` instead
- Rename `db` to `roster`
- Make `sortedRoster` a computed property, rather than a function
- Use nil coalescence for succinct `studentsInGrade(_:`) definition
- Use appropriately sized empty dictionary in `sortedRoster`,
  instead of self-mutation
- Don't replace `[String]` with `Set<String>`, though now users can :smile: