### PR TITLE
Remove default multiples (issue #127)

### DIFF
--- a/exercises/sum-of-multiples/SumOfMultiplesExample.swift
+++ b/exercises/sum-of-multiples/SumOfMultiplesExample.swift
@@ -1,32 +1,28 @@
 // Foundation not needed
 
-
-
 struct SumOfMultiples {
     
-static func toLimit (limit:Int,   inMultiples:[Int] = [] ) -> Int{
-    var multiples = inMultiples
-    let arrayLimit = Array(1..<limit)
-    
-    if multiples.count == 0 {
-        multiples = [3, 5]
-    } else if multiples[0] == 0{
-        multiples = Array(inMultiples.dropFirst())
-    }
-    
-    var itemToReturn = 0
-    
-    for each in arrayLimit{
-        var lastAdded = 0
-        for multiple in multiples {
-            if each % multiple == 0 {
-                if lastAdded != each {
-                    itemToReturn += each
-                    lastAdded = each
+    static func toLimit(limit: Int, inMultiples: [Int]) -> Int {
+        var multiples = Set(inMultiples)
+        
+        if let indexOfZero = multiples.indexOf(0) {
+            multiples.removeAtIndex(indexOfZero)
+        }
+        
+        var itemToReturn = 0
+        
+        for each in 1..<limit {
+            var lastAdded = 0
+            for multiple in multiples {
+                if each % multiple == 0 {
+                    if lastAdded != each {
+                        itemToReturn += each
+                        lastAdded = each
+                    }
                 }
             }
         }
+        
+        return itemToReturn
     }
-    return itemToReturn
-}
 }

--- a/exercises/sum-of-multiples/SumOfMultiplesTest.swift
+++ b/exercises/sum-of-multiples/SumOfMultiplesTest.swift
@@ -1,52 +1,49 @@
 import XCTest
 
-
-
-
 class SumOfMultiplesTest:XCTestCase {
     
     func testSumTo1() {
-        XCTAssertEqual(0, SumOfMultiples.toLimit(1))
+        XCTAssertEqual(0, SumOfMultiples.toLimit(1, inMultiples: [3, 5]))
     }
     
     func testSumTo3() {
-        XCTAssertEqual(3,  SumOfMultiples.toLimit(4))
+        XCTAssertEqual(3, SumOfMultiples.toLimit(4, inMultiples: [3, 5]))
     }
     
     func testSumTo10() {
-        XCTAssertEqual(23,  SumOfMultiples.toLimit(10))
+        XCTAssertEqual(23, SumOfMultiples.toLimit(10, inMultiples: [3, 5]))
     }
 
     func testSumTo100() {
-        XCTAssertEqual(2318,  SumOfMultiples.toLimit(100))
+        XCTAssertEqual(2318, SumOfMultiples.toLimit(100, inMultiples: [3, 5]))
     }
    
     func testSumTo1000() {
-        XCTAssertEqual(233168,  SumOfMultiples.toLimit(1000))
+        XCTAssertEqual(233168, SumOfMultiples.toLimit(1000, inMultiples: [3, 5]))
     }
     
     func testConfigurable_7_13_17_to_20() {
-        XCTAssertEqual(51,  SumOfMultiples.toLimit(20, inMultiples: [7, 13, 17]))
+        XCTAssertEqual(51, SumOfMultiples.toLimit(20, inMultiples: [7, 13, 17]))
     }
     
     func testConfigurable_4_6_to_15() {
-        XCTAssertEqual(30,  SumOfMultiples.toLimit(15, inMultiples: [4, 6]))
+        XCTAssertEqual(30, SumOfMultiples.toLimit(15, inMultiples: [4, 6]))
     }
     
     func testConfigurable_5_6_8_to_150() {
-        XCTAssertEqual(4419,  SumOfMultiples.toLimit(150, inMultiples: [5, 6, 8]))
+        XCTAssertEqual(4419, SumOfMultiples.toLimit(150, inMultiples: [5, 6, 8]))
     }
     
     func testConfigurable_43_47_to_10000() {
-        XCTAssertEqual(2203160,  SumOfMultiples.toLimit(10000, inMultiples: [43, 47]))
+        XCTAssertEqual(2203160, SumOfMultiples.toLimit(10000, inMultiples: [43, 47]))
     }
 
     func testConfigurable_0_to_10() {
-        XCTAssertEqual(0,  SumOfMultiples.toLimit(10, inMultiples: [0]))
+        XCTAssertEqual(0, SumOfMultiples.toLimit(10, inMultiples: [0]))
     }
 
     func testConfigurable_0_1_to_10() {
-        XCTAssertEqual(45,  SumOfMultiples.toLimit(10, inMultiples: [0, 1]))
+        XCTAssertEqual(45, SumOfMultiples.toLimit(10, inMultiples: [0, 1]))
     }
     
 }


### PR DESCRIPTION
Require all multiples to explicitly passed in, rather than using the default value of `[3,5]`, as specified in Issue #127.