### PR TITLE
dominoes: test singletons that can't be chained

### DIFF
--- a/exercises/dominoes/DominoesTest.swift
+++ b/exercises/dominoes/DominoesTest.swift
@@ -12,6 +12,11 @@ class DominoesTest: XCTestCase {
         XCTAssertTrue(Dominoes(input).chained)
     }
     
+    func testSingletonThatCantBeChained() {
+        let input = [(1, 2)]
+        XCTAssertFalse(Dominoes(input).chained)
+    }
+
     func testNoRepeatNumbers() {
         let input = [(1, 2), (3, 1), (2, 3)]
         XCTAssertTrue(Dominoes(input).chained)


### PR DESCRIPTION
Some solutions may automatically declare a singleton input to be valid
without checking it can actually be chained. This is incorrect behavior
and it is caught by this test.

Closes #131