### PR TITLE
#139 Clock exercise improvements

### DIFF
--- a/exercises/clock/ClockExample.swift
+++ b/exercises/clock/ClockExample.swift
@@ -1,79 +1,58 @@
 // Foundation not needed
 
-
-
-private extension String {
-    init(_ myType: Clock) {
-        self = myType.description
-    }
-}
-
-func ==(lhs: Clock, rhs: Clock) -> Bool {
-    return lhs.description == rhs.description
+struct Clock: Equatable, CustomStringConvertible {
     
-}
-
-func <(lhs: Clock, rhs: Clock) -> Bool{
-    let left = (lhs.hours * 60) + lhs.minutes
-    let right = (rhs.hours * 60) + rhs.minutes
-    return left < right
- 
-}
-
-
-func >(lhs: Clock, rhs: Clock) -> Bool{
-    let left = (lhs.hours * 60) + lhs.minutes
-    let right = (rhs.hours * 60) + rhs.minutes
-    return left > right
+    var hours: Int
+    var minutes: Int
     
-}
-
-
-struct Clock:Equatable, CustomStringConvertible, Comparable {
-    
-    var hours:Int
-    var minutes:Int
-    
-    init(hours:Int, minutes:Int = 0){
+    init(hours: Int, minutes: Int = 0) {
         self.hours = hours
         self.minutes = minutes
         normalize()
     }
     
-    var description: String { get {return self.toString} }
-
+    var description: String { return self.toString }
     
-    func add(minutes minutes:Int) -> Clock{
+    func add(minutes minutes:Int) -> Clock {
         return Clock(hours: self.hours, minutes: self.minutes + minutes)
     }
     
-    func subtract(minutes minutes:Int)-> Clock{
+    func subtract(minutes minutes:Int) -> Clock {
         return add(minutes: -minutes)
     }
     
-    private var toString:String {
-        
+    private var toString: String {
         let h = String(format: "%02d", self.hours)
         let m = String(format: "%02d", self.minutes)
         
         return h + ":" + m
     }
     
-    private mutating func normalize() -> Void{
-        if(minutes >= 60){
-            self.hours += (self.minutes / 60)
-            self.minutes = (self.minutes % 60)
+    private mutating func normalize() {
+        if minutes >= 60 {
+            self.hours += self.minutes / 60
+            self.minutes = self.minutes % 60
         }
-        while(self.minutes < 0){
+        while self.minutes < 0 {
             self.hours -= 1
             self.minutes += 60
         }
-        if(self.hours >= 24){
+        if self.hours >= 24 {
             self.hours = self.hours % 24
         }
-        while(self.hours < 0) {
+        while self.hours < 0 {
             self.hours += 24
         }
     }
     
+}
+
+private extension String {
+    init(_ clock: Clock) {
+        self = clock.description
+    }
+}
+
+func == (lhs: Clock, rhs: Clock) -> Bool {
+    return lhs.description == rhs.description
 }

--- a/exercises/clock/ClockTest.swift
+++ b/exercises/clock/ClockTest.swift
@@ -2,66 +2,254 @@ import XCTest
 
 
 
-// Test for Protocols: CustomStringConvertible, Equatable, Comparable
+// Test for Protocols: CustomStringConvertible, Equatable
 
 class ClockTest: XCTestCase {
     
+    // MARK: - Create: Test creating a new clock with an initial time.
+    
     func testOnTheHour() {
         XCTAssertEqual("08:00", Clock(hours: 8).description)
-        XCTAssertEqual("09:00", Clock(hours: 9).description)
     }
     
     func testPastTheHour() {
         XCTAssertEqual("11:09", Clock(hours: 11, minutes: 9).description)
     }
+        
+    func testMidnightIsZeroHours() {
+        XCTAssertEqual("00:00", Clock(hours: 24).description)
+    }
+        
+    func testHourRollsOver() {
+        XCTAssertEqual("01:00", Clock(hours: 25).description)
+    }
     
-    func testAddAFewMinutes() {
+    func testHourRollsOverContinuously() {
+        XCTAssertEqual("04:00", Clock(hours: 100).description)
+    }
+    
+    func testSixtyMinutesIsNextHour() {
+        XCTAssertEqual("02:00", Clock(hours: 1, minutes: 60).description)
+    }
+    
+    func testMinutesRollOver() {
+        XCTAssertEqual("02:40", Clock(hours: 0, minutes: 160).description)
+    }
+    
+    func testMinutesRollOverContinuously() {
+        XCTAssertEqual("04:43", Clock(hours: 0, minutes: 1723).description)
+    }
+    
+    func testHoursAndMinutesRollOver() {
+        XCTAssertEqual("11:01", Clock(hours: 201, minutes: 3001).description)
+    }
+    
+    func testHoursAndMinutesRollOverToExactlyMidnight() {
+        XCTAssertEqual("00:00", Clock(hours: 72, minutes: 8640).description)
+    }
+    
+    func testNegativeHour() {
+        XCTAssertEqual("23:15", Clock(hours: -1, minutes: 15).description)
+    }
+    
+    func testNegativeHourRollsOver() {
+        XCTAssertEqual("23:00", Clock(hours: -25).description)
+    }
+    
+    func testNegativeHourRollsOverContinuously() {
+        XCTAssertEqual("05:00", Clock(hours: -91).description)
+    }
+    
+    func testNegativeMinutes() {
+        XCTAssertEqual("00:20", Clock(hours: 1, minutes: -40).description)
+    }
+    
+    func testNegativeMinutesRollOver() {
+        XCTAssertEqual("22:20", Clock(hours: 1, minutes: -160).description)
+    }
+    
+    func testNegativeMinutesRollOverContinuously() {
+        XCTAssertEqual("16:40", Clock(hours: 1, minutes: -4820).description)
+    }
+    
+    func testNegativeHoursAndMinutesBothRollOverContinuously() {
+        XCTAssertEqual("22:10", Clock(hours: -121, minutes: -5810).description)
+    }
+    
+    // MARK: - Add: Test adding and subtracting minutes.
+    
+    func testAddMinutes() {
         let clock = Clock(hours: 10).add(minutes: 3)
         XCTAssertEqual("10:03", clock.description)
     }
     
-    func testAddOverAnHour() {
+    func testAddNoMinutes() {
+        let clock = Clock(hours: 6, minutes: 41).add(minutes: 0)
+        XCTAssertEqual("06:41", clock.description)
+    }
+    
+    func testAddToNextHour() {
+        let clock = Clock(hours: 0, minutes: 45).add(minutes: 40)
+        XCTAssertEqual("01:25", clock.description)
+    }
+    
+    func testAddMoreThanOneHour() {
         let clock = Clock(hours: 10).add(minutes: 61)
         XCTAssertEqual("11:01", String(clock))
     }
     
-    func testWrapAroundAtMidnight() {
-        let clock = Clock(hours: 23, minutes: 30).add(minutes:60)
-        XCTAssertEqual("00:30", String(clock))
+    func testAddMoreThanTwoHoursWithCarry() {
+        let clock = Clock(hours: 0, minutes: 45).add(minutes: 160)
+        XCTAssertEqual("03:25", clock.description)
+    }
+    
+    func testAddAcrossMidnight() {
+        let clock = Clock(hours: 23, minutes: 59).add(minutes: 2)
+        XCTAssertEqual("00:01", String(clock))
+    }
+    
+    func testAddMoreThanOneDay() {
+        // (1500 min = 25 hrs)
+        let clock = Clock(hours: 5, minutes: 32).add(minutes: 1500)
+        XCTAssertEqual("06:32", String(clock))
+    }
+    
+    func testAddMoreThanTwoDays() {
+        let clock = Clock(hours: 1, minutes: 1).add(minutes: 3500)
+        XCTAssertEqual("11:21", String(clock))
     }
     
     func testSubtractMinutes() {
-        let clock = Clock(hours: 10).subtract(minutes: 90)
-        XCTAssertEqual("08:30", String(clock))
+        let clock = Clock(hours: 10, minutes: 3).subtract(minutes: 3)
+        XCTAssertEqual("10:00", String(clock))
     }
     
-    func testEquivalentClocks() {
+    func testSubtractToPreviousHour() {
+        let clock = Clock(hours: 10, minutes: 3).subtract(minutes: 30)
+        XCTAssertEqual("09:33", String(clock))
+    }
+    
+    func testSubtractMoreThanAnHour() {
+        let clock = Clock(hours: 10, minutes: 3).subtract(minutes: 70)
+        XCTAssertEqual("08:53", String(clock))
+    }
+    
+    func testSubtractAcrossMidnight() {
+        let clock = Clock(hours: 0, minutes: 3).subtract(minutes: 4)
+        XCTAssertEqual("23:59", String(clock))
+    }
+    
+    func testSubtractMoreThanTwoHours() {
+        let clock = Clock(hours: 0, minutes: 0).subtract(minutes: 160)
+        XCTAssertEqual("21:20", String(clock))
+    }
+    
+    func testSubtractMoreTHanTwoHoursWithBorrow() {
+        let clock = Clock(hours: 6, minutes: 15).subtract(minutes: 160)
+        XCTAssertEqual("03:35", String(clock))
+    }
+    
+    func testSubtractMoreThanOneDay() {
+        // (1500 min = 25 hrs)
+        let clock = Clock(hours: 5, minutes: 32).subtract(minutes: 1500)
+        XCTAssertEqual("04:32", String(clock))
+    }
+    
+    func testSubtractMoreThanTwoDays() {
+        let clock = Clock(hours: 2, minutes: 20).subtract(minutes: 3000)
+        XCTAssertEqual("00:20", String(clock))
+    }
+    
+    // MARK: - Equal: Construct two separate clocks, set times, test if they are equal.
+    
+    func testClocksWithSameTime() {
         let clock1 = Clock(hours: 15, minutes: 37)
-        let clock2 = Clock(hours: 15, minutes: 36).add(minutes: 2).subtract(minutes: 1)
-        XCTAssertEqual(clock1, clock2 )
+        let clock2 = Clock(hours: 15, minutes: 37)
+        XCTAssertEqual(clock1, clock2)
     }
     
-    func testLessThanClocks() {
-        let clock1 = Clock(hours: 15, minutes: 37)
-        let clock2 = Clock(hours: 15, minutes: 36)
-        let clock3 = Clock(hours: 14, minutes: 37)
-        XCTAssertLessThan(clock2, clock1)
-        XCTAssertLessThan(clock3, clock2)
+    func testClocksAMinuteApart() {
+        let clock1 = Clock(hours: 15, minutes: 36)
+        let clock2 = Clock(hours: 15, minutes: 37)
+        XCTAssertNotEqual(clock1, clock2)
     }
     
-    
-    func testGreaterThanClocks() {
-        let clock1 = Clock(hours: 15, minutes: 37)
-        let clock2 = Clock(hours: 15, minutes: 36)
-        let clock3 = Clock(hours: 14, minutes: 37)
-        XCTAssertGreaterThan(clock1, clock2)
-        XCTAssertGreaterThan(clock2, clock3)
+    func testClocksAnHourApart() {
+        let clock1 = Clock(hours: 14, minutes: 37)
+        let clock2 = Clock(hours: 15, minutes: 37)
+        XCTAssertNotEqual(clock1, clock2)
     }
     
+    func testClocksWithHourOverflow() {
+        let clock1 = Clock(hours: 10, minutes: 37)
+        let clock2 = Clock(hours: 34, minutes: 37)
+        XCTAssertEqual(clock1, clock2)
+    }
     
-    func testWrapAroundBackwards() {
-        let clock = Clock(hours: 0, minutes: 30).subtract(minutes: 60)
-        XCTAssertEqual("23:30", String(clock))
+    func testClocksWithHourOverflowBySeveralDays() {
+        let clock1 = Clock(hours: 3, minutes: 11)
+        let clock2 = Clock(hours: 99, minutes: 11)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithNegativeHour() {
+        let clock1 = Clock(hours: 22, minutes: 40)
+        let clock2 = Clock(hours: -2, minutes: 40)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithNegativeHourThatWraps() {
+        let clock1 = Clock(hours: 17, minutes: 3)
+        let clock2 = Clock(hours: -31, minutes: 3)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithNegativeHourThatWrapsMultipleTimes() {
+        let clock1 = Clock(hours: 13, minutes: 49)
+        let clock2 = Clock(hours: -83, minutes: 49)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithMinuteOverflow() {
+        let clock1 = Clock(hours: 0, minutes: 1)
+        let clock2 = Clock(hours: 0, minutes: 1441)
+        XCTAssertEqual(clock1, clock2)
+    }
+
+    func testClocksWithMinuteOverflowBySeveralDays() {
+        let clock1 = Clock(hours: 2, minutes: 2)
+        let clock2 = Clock(hours: 2, minutes: 4322)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithNegativeMinute() {
+        let clock1 = Clock(hours: 2, minutes: 40)
+        let clock2 = Clock(hours: 3, minutes: -20)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithNegativeMinuteThatWraps() {
+        let clock1 = Clock(hours: 4, minutes: 10)
+        let clock2 = Clock(hours: 5, minutes: -1490)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithNegativeMinuteThatWrapsMultipleTimes() {
+        let clock1 = Clock(hours: 6, minutes: 15)
+        let clock2 = Clock(hours: 6, minutes: -4305)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithNegativeHoursAndMinutes() {
+        let clock1 = Clock(hours: 7, minutes: 32)
+        let clock2 = Clock(hours: -12, minutes: -268)
+        XCTAssertEqual(clock1, clock2)
+    }
+    
+    func testClocksWithNegativeHoursAndMinutesThatWrap() {
+        let clock1 = Clock(hours: 18, minutes: 7)
+        let clock2 = Clock(hours: -54, minutes: -11513)
+        XCTAssertEqual(clock1, clock2)
     }
     
 }


### PR DESCRIPTION
Implement changes to Clock exercises and test from Issue #139.

Conformance to `comparable` is no longer required for tests and has been removed.