### PR TITLE
Add error handling to Grains exercise

### DIFF
--- a/exercises/grains/GrainsExample.swift
+++ b/exercises/grains/GrainsExample.swift
@@ -16,16 +16,33 @@ func == (left: (result: UInt64, error: String?), right:(result: UInt64, error: S
 
 
 struct Grains {
-    static func square(num:Int)->(result: UInt64, error: String?){
-        if num < 1 || num > 64 {
-            return (result: 0, error: "Input[\(num)] invalid. Input should be between 1 and 64 (inclusive)")
-        } else {
-            let one:UInt64 = 1
-            let shift = UInt64(num - 1)
-            return  (result: one << shift, error:nil)
-        }}
+    enum Error: ErrorType {
+        case InputTooLow(String)
+        case InputTooHigh(String)
+    }
     
+    static func square(num: Int) throws -> UInt64 {
+        guard num >= 1 else {
+            let message = "Input[\(num)] invalid. Input should be between 1 and 64 (inclusive)"
+            throw Error.InputTooLow(message)
+        }
+        
+        guard num <= 64 else {
+            let message = "Input[\(num)] invalid. Input should be between 1 and 64 (inclusive)"
+            throw Error.InputTooHigh(message)
+        }
+       
+        let one: UInt64 = 1
+        let shift = UInt64(num - 1)
+        return one << shift
+    }
+        
     static var total:UInt64 {
-        return UINT64_MAX
+        let numbers = (1...64).map { $0 }
+        
+        return numbers.reduce(UInt64(0)) {
+            let squared = try! square($1)
+            return $0 + squared
+        }
     }
 }

--- a/exercises/grains/GrainsExample.swift
+++ b/exercises/grains/GrainsExample.swift
@@ -2,34 +2,23 @@ import Darwin
 
 
 
-func == (left: (result: UInt64, error: String?), right:(result: UInt64, error: String?) ) -> Bool
-{
-    if left.result == right.result && left.error == right.error
-    {
-        return true
-    }
-    else
-    {
-        return false
-    }
-}
-
 
 struct Grains {
-    enum Error: ErrorType {
-        case InputTooLow(String)
-        case InputTooHigh(String)
-    }
     
+    enum Error: ErrorType {
+        case inputTooLow(String)
+        case inputTooHigh(String)
+    }
+
     static func square(num: Int) throws -> UInt64 {
         guard num >= 1 else {
             let message = "Input[\(num)] invalid. Input should be between 1 and 64 (inclusive)"
-            throw Error.InputTooLow(message)
+            throw Error.inputTooLow(message)
         }
         
         guard num <= 64 else {
             let message = "Input[\(num)] invalid. Input should be between 1 and 64 (inclusive)"
-            throw Error.InputTooHigh(message)
+            throw Error.inputTooHigh(message)
         }
        
         let one: UInt64 = 1

--- a/exercises/grains/GrainsTest.swift
+++ b/exercises/grains/GrainsTest.swift
@@ -15,7 +15,7 @@ class GrainsTest: XCTestCase {
         
         do {
             let _ = try Grains.square(65)
-        } catch Grains.Error.InputTooHigh(let message) {
+        } catch Grains.Error.inputTooHigh(let message) {
             throwsInputTooHighError = true
             XCTAssertTrue(message == "Input[65] invalid. Input should be between 1 and 64 (inclusive)")
         } catch {
@@ -33,7 +33,7 @@ class GrainsTest: XCTestCase {
         
         do {
             let _ = try Grains.square(0)
-        } catch Grains.Error.InputTooLow(let message) {
+        } catch Grains.Error.inputTooLow(let message) {
             throwsInputTooLowError = true
             XCTAssertTrue(message == "Input[0] invalid. Input should be between 1 and 64 (inclusive)")
         } catch {
@@ -50,7 +50,7 @@ class GrainsTest: XCTestCase {
         
         do {
             let _ = try Grains.square(-1)
-        } catch Grains.Error.InputTooLow(let message) {
+        } catch Grains.Error.inputTooLow(let message) {
             throwsInputTooLowError = true
             XCTAssertTrue(message == "Input[-1] invalid. Input should be between 1 and 64 (inclusive)")
         } catch {
@@ -59,34 +59,34 @@ class GrainsTest: XCTestCase {
     }
     
     func testSquare1() {
-        XCTAssertTrue(try! Grains.square(1) == 1)
+        XCTAssertEqual(try! Grains.square(1), 1)
     }
     
     func testSquare2() {
-        XCTAssertTrue(try! Grains.square(2) == 2)
+        XCTAssertEqual(try! Grains.square(2), 2)
     }
 
     func testSquare3() {
-        XCTAssertTrue(try! Grains.square(3) == 4)
+        XCTAssertEqual(try! Grains.square(3), 4)
     }
 
     func testSquare4() {
-        XCTAssertTrue(try! Grains.square(4) == 8)
+        XCTAssertEqual(try! Grains.square(4), 8)
     }
 
     func testSquare16() {
-        XCTAssertTrue(try! Grains.square(16) == 32_768)
+        XCTAssertEqual(try! Grains.square(16), 32_768)
     }
 
     func testSquare32() {
-        XCTAssertTrue(try! Grains.square(32) == 2_147_483_648)
+        XCTAssertEqual(try! Grains.square(32), 2_147_483_648)
     }
 
     func testSquare64() {
-        XCTAssertTrue(try! Grains.square(64) == 9_223_372_036_854_775_808)
+        XCTAssertEqual(try! Grains.square(64), 9_223_372_036_854_775_808)
     }
     
     func testTotalGrains() {
-        XCTAssertTrue(Grains.total == 18_446_744_073_709_551_615)
+        XCTAssertEqual(Grains.total, 18_446_744_073_709_551_615)
     }
 }

--- a/exercises/grains/GrainsTest.swift
+++ b/exercises/grains/GrainsTest.swift
@@ -3,51 +3,90 @@ import XCTest
 
 
 
-// Return multiple types and compare by overloading ==
 
 class GrainsTest: XCTestCase {
     
     func testInvalidInput1() {
-        XCTAssertTrue((result: 0, error: "Input[65] invalid. Input should be between 1 and 64 (inclusive)") == Grains.square(65))
+        var throwsInputTooHighError = false
+        
+        defer {
+            XCTAssertTrue(throwsInputTooHighError)
+        }
+        
+        do {
+            let _ = try Grains.square(65)
+        } catch Grains.Error.InputTooHigh(let message) {
+            throwsInputTooHighError = true
+            XCTAssertTrue(message == "Input[65] invalid. Input should be between 1 and 64 (inclusive)")
+        } catch {
+            return
+        }
+        
     }
     
     func testInvalidInput2() {
-        XCTAssertTrue((result: 0, error: "Input[0] invalid. Input should be between 1 and 64 (inclusive)") == Grains.square(0))
+        var throwsInputTooLowError = false
+        
+        defer {
+            XCTAssertTrue(throwsInputTooLowError)
+        }
+        
+        do {
+            let _ = try Grains.square(0)
+        } catch Grains.Error.InputTooLow(let message) {
+            throwsInputTooLowError = true
+            XCTAssertTrue(message == "Input[0] invalid. Input should be between 1 and 64 (inclusive)")
+        } catch {
+            return
+        }
     }
     
     func testInvalidInput3() {
-        XCTAssertTrue((result: 0, error: "Input[-1] invalid. Input should be between 1 and 64 (inclusive)") == Grains.square(-1))
+        var throwsInputTooLowError = false
+        
+        defer {
+            XCTAssertTrue(throwsInputTooLowError)
+        }
+        
+        do {
+            let _ = try Grains.square(-1)
+        } catch Grains.Error.InputTooLow(let message) {
+            throwsInputTooLowError = true
+            XCTAssertTrue(message == "Input[-1] invalid. Input should be between 1 and 64 (inclusive)")
+        } catch {
+            return
+        }
     }
     
     func testSquare1() {
-        XCTAssertTrue((result: 1, error: nil) == Grains.square(1) )
+        XCTAssertTrue(try! Grains.square(1) == 1)
     }
     
     func testSquare2() {
-        XCTAssertTrue((result: 2, error: nil) == Grains.square(2))
+        XCTAssertTrue(try! Grains.square(2) == 2)
     }
 
     func testSquare3() {
-        XCTAssertTrue((result: 4, error: nil) == Grains.square(3))
+        XCTAssertTrue(try! Grains.square(3) == 4)
     }
 
     func testSquare4() {
-        XCTAssertTrue((result: 8, error: nil) == Grains.square(4))
+        XCTAssertTrue(try! Grains.square(4) == 8)
     }
 
     func testSquare16() {
-        XCTAssertTrue((result: 32_768, error: nil) == Grains.square(16))
+        XCTAssertTrue(try! Grains.square(16) == 32_768)
     }
 
     func testSquare32() {
-        XCTAssertTrue((result: 2_147_483_648, error: nil) == Grains.square(32))
+        XCTAssertTrue(try! Grains.square(32) == 2_147_483_648)
     }
 
     func testSquare64() {
-        XCTAssertTrue((result:9_223_372_036_854_775_808 , error: nil) == Grains.square(64))
+        XCTAssertTrue(try! Grains.square(64) == 9_223_372_036_854_775_808)
     }
     
     func testTotalGrains() {
-        XCTAssertTrue(18_446_744_073_709_551_615 == Grains.total)
+        XCTAssertTrue(Grains.total == 18_446_744_073_709_551_615)
     }
 }


### PR DESCRIPTION
Adds try/catch error handling to Grains exercise. (Partially addresses Issue #60.)

Also, improves `total` property in example by calculating it, rather than relying on the fact that it's the same as `UINT64_MAX`.