### PR TITLE
Update to use XCTAssertThrowsError

### DIFF
--- a/exercises/all-your-base/AllYourBaseTest.swift
+++ b/exercises/all-your-base/AllYourBaseTest.swift
@@ -5,15 +5,6 @@
 
 class AllYourBaseTest: XCTestCase {
 
-    func errorThrown<T, U: Error>(byExpression expression: @autoclosure () throws -> T) -> U? {
-        do {
-            let _ = try expression()
-            return nil
-        } catch {
-            return error as? U
-        }
-    }
-
     func testSingleBitOneToDecimal() {
         XCTAssertEqual(try! Base.outputDigits(inputBase: 2, inputDigits: [1], outputBase: 10), [1])
     }
@@ -63,42 +54,50 @@ class AllYourBaseTest: XCTestCase {
     }
 
     func testNegativeDigit() {
-        let error: BaseError? = errorThrown(byExpression: try Base.outputDigits(inputBase: 2, inputDigits: [1, -1, 1, 0, 1, 0], outputBase: 10))
-        XCTAssertTrue(error == .negativeDigit)
+        XCTAssertThrowsError(try Base.outputDigits(inputBase: 2, inputDigits: [1, -1, 1, 0, 1, 0], outputBase: 10)) { error in
+            XCTAssertEqual(error as? BaseError, BaseError.negativeDigit)
+        }
     }
 
     func testInvalidPositiveDigit() {
-        let error: BaseError? = errorThrown(byExpression: try Base.outputDigits(inputBase: 2, inputDigits: [1, 2, 1, 0, 1, 0], outputBase: 10))
-        XCTAssertTrue(error == .invalidPositiveDigit)
+        XCTAssertThrowsError(try Base.outputDigits(inputBase: 2, inputDigits: [1, 2, 1, 0, 1, 0], outputBase: 10)) { error in
+            XCTAssertEqual(error as? BaseError, BaseError.invalidPositiveDigit)
+        }
     }
 
     func testFirstBaseIsOne() {
-        let error: BaseError? = errorThrown(byExpression: try Base.outputDigits(inputBase: 1, inputDigits: [], outputBase: 10))
-        XCTAssertTrue(error == .invalidInputBase)
+        XCTAssertThrowsError(try Base.outputDigits(inputBase: 1, inputDigits: [], outputBase: 10)) { error in
+            XCTAssertEqual(error as? BaseError, BaseError.invalidInputBase)
+        }
     }
 
     func testSecondBaseIsOne() {
-        let error: BaseError? = errorThrown(byExpression: try Base.outputDigits(inputBase: 2, inputDigits: [1, 0, 1, 0, 1, 0], outputBase: 1))
-        XCTAssertTrue(error == .invalidOutputBase)
+        XCTAssertThrowsError(try Base.outputDigits(inputBase: 2, inputDigits: [1, 0, 1, 0, 1, 0], outputBase: 1)) { error in
+            XCTAssertEqual(error as? BaseError, BaseError.invalidOutputBase)
+        }
     }
 
     func testFirstBaseIsZero() {
-        let error: BaseError? = errorThrown(byExpression: try Base.outputDigits(inputBase: 0, inputDigits: [], outputBase: 10))
-        XCTAssertTrue(error == .invalidInputBase)
+        XCTAssertThrowsError(try Base.outputDigits(inputBase: 0, inputDigits: [], outputBase: 10)) { error in
+            XCTAssertEqual(error as? BaseError, BaseError.invalidInputBase)
+        }
     }
 
     func testSecondBaseIsZero() {
-        let error: BaseError? = errorThrown(byExpression: try Base.outputDigits(inputBase: 10, inputDigits: [7], outputBase: 0))
-        XCTAssertTrue(error == .invalidOutputBase)
+        XCTAssertThrowsError(try Base.outputDigits(inputBase: 10, inputDigits: [7], outputBase: 0)) { error in
+            XCTAssertEqual(error as? BaseError, BaseError.invalidOutputBase)
+        }
     }
 
     func testFirstBaseIsNegative() {
-        let error: BaseError? = errorThrown(byExpression: try Base.outputDigits(inputBase: -2, inputDigits: [1], outputBase: 10))
-        XCTAssertTrue(error == .invalidInputBase)
+        XCTAssertThrowsError(try Base.outputDigits(inputBase: -2, inputDigits: [1], outputBase: 10)) { error in
+            XCTAssertEqual(error as? BaseError, BaseError.invalidInputBase)
+        }
     }
 
     func testSecondBaseIsNegative() {
-        let error: BaseError? = errorThrown(byExpression: try Base.outputDigits(inputBase: 2, inputDigits: [1], outputBase: -7))
-        XCTAssertTrue(error == .invalidOutputBase)
+        XCTAssertThrowsError(try Base.outputDigits(inputBase: 2, inputDigits: [1], outputBase: -7)) { error in
+            XCTAssertEqual(error as? BaseError, BaseError.invalidOutputBase)
+        }
     }
 }

--- a/exercises/binary-search/BinarySearchTest.swift
+++ b/exercises/binary-search/BinarySearchTest.swift
@@ -11,18 +11,8 @@ class BinarySearchTest: XCTestCase {
     }
 
     func testThrowsErrorForUnsortedList() {
-        var throwsUnsortedError = false
-
-        defer {
-            XCTAssertTrue(throwsUnsortedError)
-        }
-
-        do {
-            let _ = try BinarySearch([2, 1, 4, 3, 6])
-        } catch BinarySearchError.unsorted {
-            throwsUnsortedError = true
-        } catch {
-            return
+        XCTAssertThrowsError(_ = try BinarySearch([2, 1, 4, 3, 6])) { error in
+            XCTAssertEqual(error as? BinarySearchError, BinarySearchError.unsorted)
         }
     }
 

--- a/exercises/bowling/BowlingTest.swift
+++ b/exercises/bowling/BowlingTest.swift
@@ -115,52 +115,60 @@ class BowlingTest: XCTestCase {
     }
     
     func testNegativePins() {
-        assertErrorThrown(byExpression: try game.roll(pins: -1),
-                          equals: Bowling.BowlingError.invalidNumberOfPins)
+        XCTAssertThrowsError(try game.roll(pins: -1)) { error in
+            XCTAssertEqual(error as? Bowling.BowlingError, .invalidNumberOfPins)
+        }
     }
     
     func testRollsBetterThanStrike() {
-        assertErrorThrown(byExpression: try game.roll(pins: 11),
-                          equals: Bowling.BowlingError.invalidNumberOfPins)
+        XCTAssertThrowsError(try game.roll(pins: 11)) { error in
+            XCTAssertEqual(error as? Bowling.BowlingError, .invalidNumberOfPins)
+        }
     }
     
     func testTwoNormalRollsBetterThanStrike() {
         try? game.roll(pins: 5)
-        assertErrorThrown(byExpression: try game.roll(pins: 6),
-                          equals: Bowling.BowlingError.tooManyPinsInFrame)
+        XCTAssertThrowsError(try game.roll(pins: 6)) { error in
+            XCTAssertEqual(error as? Bowling.BowlingError, .tooManyPinsInFrame)
+        }
     }
     
     func testTwoNormalRollsBetterThanStrikeInLastFrame() {
         rollNTimes(rolls: 18, pins: 0)
         try? game.roll(pins: 10)
         try? game.roll(pins: 5)
-        assertErrorThrown(byExpression: try game.roll(pins: 6),
-                          equals: Bowling.BowlingError.tooManyPinsInFrame)
+        XCTAssertThrowsError(try game.roll(pins: 6)) { error in
+            XCTAssertEqual(error as? Bowling.BowlingError, .tooManyPinsInFrame)
+        }
     }
     
     func testTakeScoreAtBeginning() {
-        assertErrorThrown(byExpression: try game.score(),
-                          equals: Bowling.BowlingError.gameInProgress)
+        XCTAssertThrowsError(try game.score()) { error in
+            XCTAssertEqual(error as? Bowling.BowlingError, .gameInProgress)
+        }
     }
     
     func testTakeScoreBeforeGameHasEnded() {
         rollNTimes(rolls: 19, pins: 5)
-        assertErrorThrown(byExpression: try game.score(),
-                          equals: Bowling.BowlingError.gameInProgress)
+        XCTAssertThrowsError(try game.score()) { error in
+            XCTAssertEqual(error as? Bowling.BowlingError, .gameInProgress)
+        }
     }
     
     func testRollsAfterTheTenthFrame() {
         rollNTimes(rolls: 20, pins: 0)
-        assertErrorThrown(byExpression: try game.roll(pins: 0),
-                          equals: Bowling.BowlingError.gameIsOver)
+        XCTAssertThrowsError(try game.roll(pins: 0)) { error in
+            XCTAssertEqual(error as? Bowling.BowlingError, .gameIsOver)
+        }
     }
     
     func testCalculateScoreBeforeFillBallsHaveBeenPlayed() {
         rollNTimes(rolls: 10, pins: 10)
-        assertErrorThrown(byExpression: try game.score(),
-                          equals: Bowling.BowlingError.gameInProgress)
+        XCTAssertThrowsError(try game.score()) { error in
+            XCTAssertEqual(error as? Bowling.BowlingError, .gameInProgress)
+        }
     }
-        
+    
     private func rollNTimes(rolls: Int, pins: Int...) {
         for _ in 1...rolls {
             pins.forEach {
@@ -169,17 +177,4 @@ class BowlingTest: XCTestCase {
         }
     }
     
-    private func assertErrorThrown<T, U: Error>(byExpression expression: @autoclosure () throws -> T, equals expectedError: U) where U: Equatable {
-        do {
-            let _ = try expression()
-            XCTFail("Call did not throw.")
-        } catch {
-            guard let error = error as? U else {
-                XCTFail("Could not cast error to expected type.")
-                return
-            }
-            
-            XCTAssertEqual(error, expectedError, "Cast succeeded, but error was \(error) instead of \(expectedError).")
-        }
-    }
 }

--- a/exercises/grains/GrainsTest.swift
+++ b/exercises/grains/GrainsTest.swift
@@ -6,54 +6,32 @@
 class GrainsTest: XCTestCase {
 
     func testInvalidInput1() {
-        var throwsInputTooHighError = false
-
-        defer {
-            XCTAssertTrue(throwsInputTooHighError)
+        XCTAssertThrowsError(try Grains.square(65)) { error in
+            if case let Grains.GrainsError.inputTooHigh(message) = error {
+                XCTAssertTrue(message == "Input[65] invalid. Input should be between 1 and 64 (inclusive)")
+            } else {
+                XCTFail()
+            }
         }
-
-        do {
-            let _ = try Grains.square(65)
-        } catch Grains.GrainsError.inputTooHigh(let message) {
-            throwsInputTooHighError = true
-            XCTAssertTrue(message == "Input[65] invalid. Input should be between 1 and 64 (inclusive)")
-        } catch {
-            return
-        }
-
     }
 
     func testInvalidInput2() {
-        var throwsInputTooLowError = false
-
-        defer {
-            XCTAssertTrue(throwsInputTooLowError)
-        }
-
-        do {
-            let _ = try Grains.square(0)
-        } catch Grains.GrainsError.inputTooLow(let message) {
-            throwsInputTooLowError = true
-            XCTAssertTrue(message == "Input[0] invalid. Input should be between 1 and 64 (inclusive)")
-        } catch {
-            return
+        XCTAssertThrowsError(try Grains.square(0)) { error in
+            if case let Grains.GrainsError.inputTooLow(message) = error {
+                XCTAssertTrue(message == "Input[0] invalid. Input should be between 1 and 64 (inclusive)")
+            } else {
+                XCTFail()
+            }
         }
     }
 
     func testInvalidInput3() {
-        var throwsInputTooLowError = false
-
-        defer {
-            XCTAssertTrue(throwsInputTooLowError)
-        }
-
-        do {
-            let _ = try Grains.square(-1)
-        } catch Grains.GrainsError.inputTooLow(let message) {
-            throwsInputTooLowError = true
-            XCTAssertTrue(message == "Input[-1] invalid. Input should be between 1 and 64 (inclusive)")
-        } catch {
-            return
+        XCTAssertThrowsError(try Grains.square(-1)) { error in
+            if case let Grains.GrainsError.inputTooLow(message) = error {
+                XCTAssertTrue(message == "Input[-1] invalid. Input should be between 1 and 64 (inclusive)")
+            } else {
+                XCTFail()
+            }
         }
     }
 

--- a/exercises/largest-series-product/LargestSeriesProductTest.swift
+++ b/exercises/largest-series-product/LargestSeriesProductTest.swift
@@ -49,18 +49,8 @@ class LargestSeriesProductTest: XCTestCase {
     }
 
     func testRejectsSpanLongerThanStringLength() {
-        var throwsSpanLongerThanStringLengthError = false
-
-        defer {
-            XCTAssertTrue(throwsSpanLongerThanStringLengthError)
-        }
-
-        do {
-            let _ = try NumberSeries("123").largestProduct(4)
-        } catch NumberSeries.NumberSeriesError.spanLongerThanStringLength {
-            throwsSpanLongerThanStringLengthError = true
-        } catch {
-            return
+        XCTAssertThrowsError(_ = try NumberSeries("123").largestProduct(4)) { error in
+            XCTAssertEqual(error as? NumberSeries.NumberSeriesError, .spanLongerThanStringLength)
         }
     }
 
@@ -73,50 +63,20 @@ class LargestSeriesProductTest: XCTestCase {
     }
 
     func testRejectsEmptyStringAndNonzeroSpan() {
-        var throwsSpanLongerThanStringLengthError = false
-
-        defer {
-            XCTAssertTrue(throwsSpanLongerThanStringLengthError)
-        }
-
-        do {
-            let _ = try NumberSeries("").largestProduct(1)
-        } catch NumberSeries.NumberSeriesError.spanLongerThanStringLength {
-            throwsSpanLongerThanStringLengthError = true
-        } catch {
-            return
+        XCTAssertThrowsError(_ = try NumberSeries("").largestProduct(1)) { error in
+            XCTAssertEqual(error as? NumberSeries.NumberSeriesError, .spanLongerThanStringLength)
         }
     }
 
     func testRejectsInvalidCharacterInDigits() {
-        var throwsInvalidCharacterError = false
-
-        defer {
-            XCTAssertTrue(throwsInvalidCharacterError)
-        }
-
-        do {
-            let _ = try NumberSeries("1234a5").largestProduct(2)
-        } catch NumberSeries.NumberSeriesError.invalidCharacter {
-            throwsInvalidCharacterError = true
-        } catch {
-            return
+        XCTAssertThrowsError(_ = try NumberSeries("1234a5").largestProduct(2)) { error in
+            XCTAssertEqual(error as? NumberSeries.NumberSeriesError, .invalidCharacter)
         }
     }
 
     func testRejectsNegativeSpan() {
-        var throwsNegativeSpanError = false
-
-        defer {
-            XCTAssertTrue(throwsNegativeSpanError)
-        }
-
-        do {
-            let _ = try NumberSeries("12345").largestProduct(-1)
-        } catch NumberSeries.NumberSeriesError.negativeSpan {
-            throwsNegativeSpanError = true
-        } catch {
-            return
+        XCTAssertThrowsError(_ = try NumberSeries("12345").largestProduct(-1)) { error in
+            XCTAssertEqual(error as? NumberSeries.NumberSeriesError, .negativeSpan)
         }
     }
 

--- a/exercises/minesweeper/MinesweeperTest.swift
+++ b/exercises/minesweeper/MinesweeperTest.swift
@@ -66,53 +66,26 @@ class MinesweeperTest: XCTestCase {
     }
 
     func testDifferentLength() {
-        var throwsDifferentLengthError = false
-
-        defer {
-            XCTAssertTrue(throwsDifferentLengthError)
-        }
-
         let input = ["+-+", "| |", "|*  |", "|  |", "+-+"]
-        do {
-            let _ = try Board(input)
-        } catch Board.BoardError.differentLength {
-            throwsDifferentLengthError = true
-        } catch {
-            return
+        
+        XCTAssertThrowsError(_ = try Board(input)) { error in
+            XCTAssertEqual(error as? Board.BoardError, .differentLength)
         }
     }
 
     func testFaultyBorder() {
-        var throwsFaultyBorderError = false
-
-        defer {
-            XCTAssertTrue(throwsFaultyBorderError)
-        }
-
         let input = ["+-----+", "*   * |", "+-- --+"]
-        do {
-            let _ = try Board(input)
-        } catch Board.BoardError.faultyBorder {
-            throwsFaultyBorderError = true
-        } catch {
-            return
+        
+        XCTAssertThrowsError(_ = try Board(input)) { error in
+            XCTAssertEqual(error as? Board.BoardError, .faultyBorder)
         }
     }
 
     func testInvalidCharacter() {
-        var throwsInvalidCharacterError = false
-
-        defer {
-            XCTAssertTrue(throwsInvalidCharacterError)
-        }
-
         let input = ["+-----+", "|X  * |", "+-----+"]
-        do {
-            let _ = try Board(input)
-        } catch Board.BoardError.invalidCharacter {
-            throwsInvalidCharacterError = true
-        } catch {
-            return
+        
+        XCTAssertThrowsError(_ = try Board(input)) { error in
+            XCTAssertEqual(error as? Board.BoardError, .invalidCharacter)
         }
     }
 

--- a/exercises/ocr-numbers/OcrNumbersTest.swift
+++ b/exercises/ocr-numbers/OcrNumbersTest.swift
@@ -145,44 +145,25 @@ class OcrNumbersTest: XCTestCase {
     }
 
     func testThrowsInvalidNumberOfLinesError() {
-        var throwsInvalidNumberOfLinesError = false
-
-        defer {
-            XCTAssertTrue(throwsInvalidNumberOfLinesError)
-        }
-
-        do {
-            let text =
-                "    _  _ \n" +
-            "  | _| _|"
-            let _ = try OCR(text)
-        } catch OCR.OCRError.invalidNumberOfLines {
-            throwsInvalidNumberOfLinesError = true
-            return
-        } catch {
-            return
+        let text =
+            "    _  _ \n" +
+        "  | _| _|"
+        
+        XCTAssertThrowsError(_ = try OCR(text)) { error in
+            XCTAssertEqual(error as? OCR.OCRError, .invalidNumberOfLines)
         }
     }
 
     func testThrowsInvalidNumberOfColumnsError() {
-        var throwsInvalidNumberOfColumnsError = false
+        let text =
+            "    _\n" +
+                "  | _\n" +
+                "  ||_\n" +
+        "     "
 
-        defer {
-            XCTAssertTrue(throwsInvalidNumberOfColumnsError)
-        }
-
-        do {
-            let text =
-                "    _\n" +
-                    "  | _\n" +
-                    "  ||_\n" +
-            "     "
-            let _ = try OCR(text)
-        } catch OCR.OCRError.invalidNumberOfColumns {
-            throwsInvalidNumberOfColumnsError = true
-            return
-        } catch {
-            return
+        
+        XCTAssertThrowsError(_ = try OCR(text)) { error in
+            XCTAssertEqual(error as? OCR.OCRError, .invalidNumberOfColumns)
         }
     }
 

--- a/exercises/queen-attack/QueenAttackTest.swift
+++ b/exercises/queen-attack/QueenAttackTest.swift
@@ -28,50 +28,20 @@ class QueenAttackTest: XCTestCase {
     }
 
     func testIncorrectNumberOfCoordinates() {
-        var throwsIncorrectNumberOfCoordinates = false
-
-        defer {
-            XCTAssertTrue(throwsIncorrectNumberOfCoordinates)
-        }
-
-        do {
-            let _ = try Queens(white: [1, 2, 3], black: [4, 5])
-        } catch Queens.InitError.incorrectNumberOfCoordinates {
-            throwsIncorrectNumberOfCoordinates = true
-        } catch {
-            return
+        XCTAssertThrowsError(_ = try Queens(white: [1, 2, 3], black: [4, 5])) { error in
+            XCTAssertEqual(error as? Queens.InitError, .incorrectNumberOfCoordinates)
         }
     }
 
     func testInvalidCoordinates() {
-        var throwsInvalidCoordinates = false
-
-        defer {
-            XCTAssertTrue(throwsInvalidCoordinates)
-        }
-
-        do {
-            let _ = try Queens(white: [-3, 0], black: [2, 481])
-        } catch Queens.InitError.invalidCoordinates {
-            throwsInvalidCoordinates = true
-        } catch {
-            return
+        XCTAssertThrowsError(_ = try Queens(white: [-3, 0], black: [2, 481])) { error in
+            XCTAssertEqual(error as? Queens.InitError, .invalidCoordinates)
         }
     }
 
     func testCannotOccupySameSpace() {
-        var throwsSameSpaceError = false
-
-        defer {
-            XCTAssertTrue(throwsSameSpaceError)
-        }
-
-        do {
-            let _ = try Queens(white: [2, 4], black: [2, 4])
-        } catch Queens.InitError.sameSpace {
-            throwsSameSpaceError = true
-        } catch {
-            return
+        XCTAssertThrowsError(_ = try Queens(white: [2, 4], black: [2, 4])) { error in
+            XCTAssertEqual(error as? Queens.InitError, .sameSpace)
         }
     }
 


### PR DESCRIPTION
Resolves #181

Use new `XCTAssertThrowsError` method to clean up tests.