### PR TITLE
Add Transpose exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -493,6 +493,14 @@
         ]
     },
     {
+        "difficulty": 6,
+        "slug": "transpose",
+        "topics": [
+            "Strings",
+            "Transforming"
+        ]
+    },
+    {
         "difficulty": 7,
         "slug": "bracket-push",
         "topics": [

--- a/exercises/transpose/TransposeExample.swift
+++ b/exercises/transpose/TransposeExample.swift
@@ -1,0 +1,35 @@
+struct Transpose {
+    static func transpose(_ input: [String]) -> [String] {
+        let maxLineLength = input.map { $0.characters.count }.max()
+
+        guard let maxLength = maxLineLength else {
+            return []
+        }
+
+        var result = [String](repeatElement("", count: maxLength))
+
+        for i in 0..<maxLength {
+            for line in input {
+                if let start = line.index(line.startIndex, offsetBy: i, limitedBy: line.endIndex),
+                    let end = line.index(start, offsetBy: 1, limitedBy: line.endIndex) {
+                    let character = line[start..<end]
+                    result[i].append(character)
+                } else {
+                    result[i].append(" ")
+                }
+            }
+        }
+
+        return result.map { stripTrailingWhitespace($0) }
+    }
+
+    private static func stripTrailingWhitespace(_ input: String) -> String {
+        var result = input
+
+        while result.hasSuffix(" ") {
+            result.remove(at: result.index(before: result.endIndex))
+        }
+
+        return result
+    }
+}

--- a/exercises/transpose/TransposeTest.swift
+++ b/exercises/transpose/TransposeTest.swift
@@ -1,0 +1,135 @@
+#if swift(>=3.0)
+    import XCTest
+#endif
+
+class TransposeTest: XCTestCase {
+
+    func testEmptyInput() {
+        XCTAssertEqual(Transpose.transpose([]), [])
+    }
+
+    func testTwoCharactersInARow() {
+        XCTAssertEqual(Transpose.transpose(["A1"]), ["A", "1"])
+    }
+
+    func testTwoCharactersInAColumn() {
+        XCTAssertEqual(Transpose.transpose(["A", "1"]), ["A1"])
+    }
+
+    func testSimple() {
+        XCTAssertEqual(Transpose.transpose(["ABC", "123"]), ["A1", "B2", "C3"])
+    }
+
+    func testSingleLine() {
+        let expected = ["S", "i", "n", "g", "l", "e", "", "l", "i", "n", "e", "."]
+        XCTAssertEqual(Transpose.transpose(["Single line."]), expected)
+    }
+
+    func testFirstLineLongerThanSecondLine() {
+        let input = ["The fourth line.", "The fifth line."]
+        let expected = ["TT", "hh", "ee", "", "ff", "oi", "uf", "rt", "th", "h", " l", "li", "in", "ne", "e.", "."]
+        XCTAssertEqual(Transpose.transpose(input), expected)
+    }
+
+    func testSecondLineLongerThanFirstLine() {
+        let input = ["The first line.", "The second line."]
+        let expected = ["TT", "hh", "ee", "", "fs", "ie", "rc", "so", "tn", " d", "l", "il", "ni", "en", ".e", " ."]
+        XCTAssertEqual(Transpose.transpose(input), expected)
+    }
+
+    func testSquare() {
+        let input = ["HEART", "EMBER", "ABUSE", "RESIN", "TREND"]
+        let expected = ["HEART", "EMBER", "ABUSE", "RESIN", "TREND"]
+        XCTAssertEqual(Transpose.transpose(input), expected)
+    }
+
+    func testRectangle() {
+        let input = ["FRACTURE", "OUTLINED", "BLOOMING", "SEPTETTE"]
+        let expected = ["FOBS", "RULE", "ATOP", "CLOT", "TIME", "UNIT", "RENT", "EDGE"]
+        XCTAssertEqual(Transpose.transpose(input), expected)
+    }
+
+    func testTriangle() {
+        let input = ["T", "EE", "AAA", "SSSS", "EEEEE", "RRRRRR"]
+        let expected = ["TEASER", " EASER", "  ASER", "   SER", "    ER", "     R"]
+        XCTAssertEqual(Transpose.transpose(input), expected)
+    }
+
+    func testManyLines() {
+        let input = [
+            "Chor. Two households, both alike in dignity,",
+            "In fair Verona, where we lay our scene,",
+            "From ancient grudge break to new mutiny,",
+            "Where civil blood makes civil hands unclean.",
+            "From forth the fatal loins of these two foes",
+            "A pair of star-cross'd lovers take their life;",
+            "Whose misadventur'd piteous overthrows",
+            "Doth with their death bury their parents' strife.",
+            "The fearful passage of their death-mark'd love,",
+            "And the continuance of their parents' rage,",
+            "Which, but their children's end, naught could remove,",
+            "Is now the two hours' traffic of our stage;",
+            "The which if you with patient ears attend,",
+            "What here shall miss, our toil shall strive to mend."
+        ]
+
+        let expected = [
+            "CIFWFAWDTAWITW",
+            "hnrhr hohnhshh",
+            "o oeopotedi ea",
+            "rfmrmash  cn t",
+            ".a e ie fthow",
+            " ia fr weh,whh",
+            "Trnco miae  ie",
+            "w ciroitr btcr",
+            "oVivtfshfcuhhe",
+            " eeih a uote",
+            "hrnl sdtln  is",
+            "oot ttvh tttfh",
+            "un bhaeepihw a",
+            "saglernianeoyl",
+            "e,ro -trsui ol",
+            "h uofcu sarhu",
+            "owddarrdan o m",
+            "lhg to'egccuwi",
+            "deemasdaeehris",
+            "sr als t  ists",
+            ",ebk 'phool'h,",
+            "  reldi ffd",
+            "bweso tb  rtpo",
+            "oea ileutterau",
+            "t kcnoorhhnatr",
+            "hl isvuyee'fi",
+            " atv es iisfet",
+            "ayoior trr ino",
+            "l  lfsoh  ecti",
+            "ion   vedpn  l",
+            "kuehtteieadoe",
+            "erwaharrar,fas",
+            "   nekt te  rh",
+            "ismdsehphnnosa",
+            "ncuse ra-tau l",
+            " et  tormsural",
+            "dniuthwea'g t",
+            "iennwesnr hsts",
+            "g,ycoi tkrttet",
+            "n ,l r s'a anr",
+            "i  ef  'dgcgdi",
+            "t  aol   eoe,v",
+            "y  nei sl,u; e",
+            ",  .sf to l",
+            "     e rv d  t",
+            "     ; ie    o",
+            "       f, r",
+            "       e  e  m",
+            "       .  m  e",
+            "          o  n",
+            "          v  d",
+            "          e  .",
+            "          ,"
+        ]
+
+        XCTAssertEqual(Transpose.transpose(input), expected)
+    }
+
+}

--- a/xcodeProject/xSwift.xcodeproj/project.pbxproj
+++ b/xcodeProject/xSwift.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		E90D62081C653ADC00C266D3 /* PalindromeProductsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90D62071C653ADC00C266D3 /* PalindromeProductsTest.swift */; };
 		E90DE39C1D3E812300F3B881 /* AllYourBaseExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90DE39B1D3E812300F3B881 /* AllYourBaseExample.swift */; };
 		E90DE39E1D3E818000F3B881 /* AllYourBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90DE39D1D3E818000F3B881 /* AllYourBaseTest.swift */; };
+		E9443F251DF5C02700A468B7 /* TransposeExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9443F241DF5C02700A468B7 /* TransposeExample.swift */; };
+		E9443F271DF5C04000A468B7 /* TransposeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9443F261DF5C04000A468B7 /* TransposeTest.swift */; };
 		E94BDECF1C510E68009318BB /* BinarySearchExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94BDECD1C510E68009318BB /* BinarySearchExample.swift */; };
 		E94BDED01C510E68009318BB /* BinarySearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94BDECE1C510E68009318BB /* BinarySearchTest.swift */; };
 		E951B6BD1D466045009EB5B6 /* BracketPushExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = E951B6BC1D466045009EB5B6 /* BracketPushExample.swift */; };
@@ -285,6 +287,8 @@
 		E90D62071C653ADC00C266D3 /* PalindromeProductsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = PalindromeProductsTest.swift; path = "palindrome-products/PalindromeProductsTest.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E90DE39B1D3E812300F3B881 /* AllYourBaseExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AllYourBaseExample.swift; path = "../all-your-base/AllYourBaseExample.swift"; sourceTree = "<group>"; };
 		E90DE39D1D3E818000F3B881 /* AllYourBaseTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AllYourBaseTest.swift; path = "../all-your-base/AllYourBaseTest.swift"; sourceTree = "<group>"; };
+		E9443F241DF5C02700A468B7 /* TransposeExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TransposeExample.swift; path = ../transpose/TransposeExample.swift; sourceTree = "<group>"; };
+		E9443F261DF5C04000A468B7 /* TransposeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TransposeTest.swift; path = ../transpose/TransposeTest.swift; sourceTree = "<group>"; };
 		E94BDECD1C510E68009318BB /* BinarySearchExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BinarySearchExample.swift; path = "binary-search/BinarySearchExample.swift"; sourceTree = "<group>"; };
 		E94BDECE1C510E68009318BB /* BinarySearchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = BinarySearchTest.swift; path = "binary-search/BinarySearchTest.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E951B6BC1D466045009EB5B6 /* BracketPushExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BracketPushExample.swift; path = "../bracket-push/BracketPushExample.swift"; sourceTree = "<group>"; };
@@ -397,6 +401,7 @@
 				1E9A63701C506EFC00E28AE1 /* strain */,
 				1E9A63731C506EFC00E28AE1 /* sum-of-multiples */,
 				1E9A63761C506EFC00E28AE1 /* tournament */,
+				E9443F201DF5BFBF00A468B7 /* transpose */,
 				1E9A63791C506EFC00E28AE1 /* triangle */,
 				1E9A637C1C506EFC00E28AE1 /* trinary */,
 				1E9A637F1C506EFC00E28AE1 /* twelve-days */,
@@ -983,6 +988,16 @@
 			path = acronym;
 			sourceTree = "<group>";
 		};
+		E9443F201DF5BFBF00A468B7 /* transpose */ = {
+			isa = PBXGroup;
+			children = (
+				E9443F241DF5C02700A468B7 /* TransposeExample.swift */,
+				E9443F261DF5C04000A468B7 /* TransposeTest.swift */,
+			);
+			name = transpose;
+			path = tournament;
+			sourceTree = "<group>";
+		};
 		E94BDECB1C510DF4009318BB /* binary-search */ = {
 			isa = PBXGroup;
 			children = (
@@ -1288,12 +1303,14 @@
 				E9AFA17A1C614DA0006AD72D /* HouseTest.swift in Sources */,
 				1E9A63B11C506EFD00E28AE1 /* LinkedListTest.swift in Sources */,
 				1E9A63921C506EFD00E28AE1 /* BinaryExample.swift in Sources */,
+				E9443F271DF5C04000A468B7 /* TransposeTest.swift in Sources */,
 				1E9A638F1C506EFD00E28AE1 /* AnagramTest.swift in Sources */,
 				1E9A63D51C506EFD00E28AE1 /* SecretHandshakeTest.swift in Sources */,
 				1E9A63BA1C506EFD00E28AE1 /* OctalExample.swift in Sources */,
 				1E9A63C81C506EFD00E28AE1 /* RaindropsExample.swift in Sources */,
 				E951B6BF1D466058009EB5B6 /* BracketPushTest.swift in Sources */,
 				E9AFA1601C5BFC57006AD72D /* LargestSeriesProductExample.swift in Sources */,
+				E9443F251DF5C02700A468B7 /* TransposeExample.swift in Sources */,
 				E9AFA16D1C5EF4EA006AD72D /* MatrixTest.swift in Sources */,
 				1E9A638E1C506EFD00E28AE1 /* AnagramExample.swift in Sources */,
 				1E9A63A01C506EFD00E28AE1 /* GigasecondExample.swift in Sources */,


### PR DESCRIPTION
* Add Transpose exercise

In contrast with the Ruby version, the Swift version operates on arrays of `String`s, since the syntax for multi-line strings is rather cumbersome.