### PR TITLE
Bug fix for #256 Swift Matrix testExtractAColumn test has extra space…

### DIFF
--- a/exercises/matrix/Tests/MatrixTests/MatrixTests.swift
+++ b/exercises/matrix/Tests/MatrixTests/MatrixTests.swift
@@ -23,7 +23,7 @@ class MatrixTests: XCTestCase {
     }
 
     func testExtractAColumn() {
-        let matrix = Matrix("1 2 3\n4 5 6\n7 8 9\n 8 7 6")
+        let matrix = Matrix("1 2 3\n4 5 6\n7 8 9\n8 7 6")
         XCTAssertEqual([1, 4, 7, 8], matrix.columns[0])
     }
 


### PR DESCRIPTION
This is a bug fix to fix issue #256.  The only change is remove one errant space after the \n.  Thanks.