### PR TITLE
Remove license info from README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+Copyright (c) 2017 Exercism, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,9 +9,3 @@ Please see the [contributing guide](https://github.com/exercism/x-api/blob/maste
 ## Swift Track
 
 We use Travis CI to automatically run all the unit tests on the code that is going to be checked in. In addition we also have [SwiftLint](https://github.com/realm/SwiftLint) set up to make sure that the code is consistent across all exercises. Please run `swiftlint autocorrect --format` on your code before submitting a PR. Check the travis file to see which version of swift we are testing against. Make sure all the tests pass locally using the swift package manager. Keep in mind that we support Linux so the tests need to also pass on linux on Travis. 
-
-## License
-
-The MIT License (MIT)
-
-Copyright (c) 2017 Katrina Owen, _@kytrinyx.com


### PR DESCRIPTION
We don't need the duplication, especially now that the GitHub interface shows the
license information on the main page of the repository when it can be detected
directly from the LICENSE file.

This also updates the license file to reassign copyright to the Exercism legal entity.