### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions Append
 
-## Implementation
+## Track specific instructions
 
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 You will have to implement your own equality operator for the `ComplexNumber` object.
 This will pose the challenge of comparing two floating point numbers.

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Append
+# Instructions append
+
+## Implementation
 
 You will have to implement your own equality operator for the `ComplexNumber` object.
 This will pose the challenge of comparing two floating point numbers.

--- a/exercises/practice/knapsack/.docs/instructions.append.md
+++ b/exercises/practice/knapsack/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Item representation
 
 The items are represented by the `Item` struct in `Item.swift`.

--- a/exercises/practice/knapsack/.docs/instructions.append.md
+++ b/exercises/practice/knapsack/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Item representation
+## Track specific instructions
 
 The items are represented by the `Item` struct in `Item.swift`.

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Adding method to the Int structure
 
 This exercise focuses on adding methods to the `Int` structure in Swift.

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Adding method to the Int structure
+## Track specific instructions
 
 This exercise focuses on adding methods to the `Int` structure in Swift.
 This is easiest done through using [extensions][extensions].

--- a/exercises/practice/strain/.docs/instructions.append.md
+++ b/exercises/practice/strain/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Adding method to the Array structure
 
 This exercise focuses on adding methods to the `Array` structure in Swift.

--- a/exercises/practice/strain/.docs/instructions.append.md
+++ b/exercises/practice/strain/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Adding method to the Array structure
+## Track specific instructions
 
 This exercise focuses on adding methods to the `Array` structure in Swift.
 This is easiest done through using [extensions][extensions].


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.